### PR TITLE
Update import syntax to use identifiers

### DIFF
--- a/syntax/grammar.txt
+++ b/syntax/grammar.txt
@@ -39,7 +39,7 @@ AssignStmt   = Expression ('=' | '+=' | '-=' | '*=' | '/=' | '//=' | '%=' | '&='
 ExprStmt     = Expression .
 
 LoadStmt = 'load' '(' string {',' [identifier '='] string} [','] ')' .
-ImportStmt = 'from' string 'import' identifier {',' identifier} [','] '.'
+ImportStmt = 'from' identifier 'import' identifier {',' identifier} [','] '.'
 
 Test = LambdaExpr
      | IfExpr

--- a/syntax/parse.go
+++ b/syntax/parse.go
@@ -407,16 +407,22 @@ func (p *parser) parseLoadStmt() *LoadStmt {
 
 // parseImportStmt parses a Python-like import statement of the form:
 //
-//	from "module" import a, b,
+//	from module import a, b,
 //
 // It returns a LoadStmt equivalent to load("module", "a", "b").
 func (p *parser) parseImportStmt() *LoadStmt {
 	fromPos := p.nextToken() // consume FROM
 
-	if p.tok != STRING {
-		p.in.errorf(p.in.pos, "first operand of load statement must be a string literal")
+	if p.tok != IDENT {
+		p.in.errorf(p.in.pos, "first operand of load statement must be an identifier")
 	}
-	module := p.parsePrimary().(*Literal)
+	moduleIdent := p.parseIdent()
+	module := &Literal{
+		Token:    STRING,
+		TokenPos: moduleIdent.NamePos,
+		Raw:      moduleIdent.Name,
+		Value:    moduleIdent.Name,
+	}
 
 	p.consume(IMPORT)
 

--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -172,10 +172,10 @@ else:
 			`(LoadStmt Module="" From=(a c) To=(a b))`},
 		{`if True: load("", "a", b="c")`, // load needn't be at toplevel
 			`(IfStmt Cond=True True=((LoadStmt Module="" From=(a c) To=(a b))))`},
-		{`from "" import a, b`,
-			`(LoadStmt Module="" From=(a b) To=(a b))`},
-		{`if True: from "" import a, b`,
-			`(IfStmt Cond=True True=((LoadStmt Module="" From=(a b) To=(a b))))`},
+		{`from foo import a, b`,
+			`(LoadStmt Module="foo" From=(a b) To=(a b))`},
+		{`if True: from foo import a, b`,
+			`(IfStmt Cond=True True=((LoadStmt Module="foo" From=(a b) To=(a b))))`},
 		{`def f(x, *args, **kwargs):
 	pass`,
 			`(DefStmt Name=f Params=(x (UnaryExpr Op=* X=args) (UnaryExpr Op=** X=kwargs)) Body=((BranchStmt Token=pass)))`},

--- a/syntax/testdata/errors.star
+++ b/syntax/testdata/errors.star
@@ -157,18 +157,18 @@ load("a", "x")
 load("a", "x", y2="y")
 load("a", x2="x", "y") # => positional-before-named arg check happens later (!)
 ---
-from "" import ### "load statement must import at least 1 symbol"
+from foo import ### "load statement must import at least 1 symbol"
 ---
-from "" import 1 ### `load operand must be "name" or localname="name" \(got int literal\)`
+from foo import 1 ### `load operand must be "name" or localname="name" \(got int literal\)`
 ---
-from "a" import x # ok
+from a import x # ok
 ---
-from 1 import x ### "first operand of load statement must be a string literal"
+from 1 import x ### "first operand of load statement must be an identifier"
 ---
 # All of these parse.
-from "a" import x
-from "a" import x, y
-from "a" import x,
+from a import x
+from a import x, y
+from a import x,
 ---
 # 'load' is not an identifier
 load = 1 ### `got '=', want '\('`
@@ -188,7 +188,7 @@ def f(load): ### `not an identifier`
 load("module", "x",)
 ---
 # An import statement allows a trailing comma.
-from "module" import x,
+from module import x,
 ---
 x = 1 + ### "got newline, want primary expression"
 2 

--- a/syntax/testdata/scan.star
+++ b/syntax/testdata/scan.star
@@ -18,10 +18,10 @@ load("//go/private:repositories.bzl", "go_repositories")
 load("//go/private:go_repository.bzl", "go_repository", "new_go_repository")
 load("//go/private:go_prefix.bzl", "go_prefix")
 load("//go/private:json.bzl", "json_marshal")
-from "//go/private:repositories.bzl" import go_repositories
-from "//go/private:go_repository.bzl" import go_repository, new_go_repository
-from "//go/private:go_prefix.bzl" import go_prefix
-from "//go/private:json.bzl" import json_marshal
+from repositories import go_repositories
+from go_repository_module import go_repository, new_go_repository
+from go_prefix_module import go_prefix
+from json_module import json_marshal
 
 """These are bare-bones Go rules.
 


### PR DESCRIPTION
## Summary
- support `from package import a, b` syntax using identifier package names
- convert identifier module name to a string literal in the parser
- adjust grammar and tests to reflect identifier-based import

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68546836c54c83249e0960ff42fbe4b6