### PR TITLE
Add import sugar for load

### DIFF
--- a/syntax/parse_test.go
+++ b/syntax/parse_test.go
@@ -180,8 +180,12 @@ else:
 			`(LoadStmt Module="foo" From=(a b) To=(aa bb))`},
 		{`if True: from foo import a as aa, b as bb`,
 			`(IfStmt Cond=True True=((LoadStmt Module="foo" From=(a b) To=(aa bb))))`},
+		{`import foo`,
+			`(LoadStmt Module="foo" From=(*) To=(foo))`},
+		{`import foo as bar`,
+			`(LoadStmt Module="foo" From=(*) To=(bar))`},
 		{`def f(x, *args, **kwargs):
-	pass`,
+        pass`,
 			`(DefStmt Name=f Params=(x (UnaryExpr Op=* X=args) (UnaryExpr Op=** X=kwargs)) Body=((BranchStmt Token=pass)))`},
 		{`def f(**kwargs, *args): pass`,
 			`(DefStmt Name=f Params=((UnaryExpr Op=** X=kwargs) (UnaryExpr Op=* X=args)) Body=((BranchStmt Token=pass)))`},


### PR DESCRIPTION
## Summary
- support `import module` and `import module as alias`
- treat imports as `load` statements when parsing
- add parse tests for the new forms

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68547b6fe2048324b1b438428a420cac