### PR TITLE
Add import syntax coverage

### DIFF
--- a/syntax/grammar.txt
+++ b/syntax/grammar.txt
@@ -39,7 +39,10 @@ AssignStmt   = Expression ('=' | '+=' | '-=' | '*=' | '/=' | '//=' | '%=' | '&='
 ExprStmt     = Expression .
 
 LoadStmt = 'load' '(' string {',' [identifier '='] string} [','] ')' .
-ImportStmt = 'from' identifier 'import' identifier ['as' identifier] {',' identifier ['as' identifier]} [','] .
+ImportStmt =
+        'from' identifier 'import' identifier ['as' identifier] {',' identifier ['as' identifier]} [',']
+      | 'import' identifier ['as' identifier]
+      .
 
 Test = LambdaExpr
      | IfExpr

--- a/syntax/testdata/errors.star
+++ b/syntax/testdata/errors.star
@@ -190,6 +190,12 @@ load("module", "x",)
 # An import statement allows a trailing comma.
 from module import x,
 ---
+# All import statement variants parse.
+from package import a, b
+from package import a as aa, b as bb
+import package
+import package as pkg
+---
 x = 1 + ### "got newline, want primary expression"
 2 
 ---

--- a/syntax/testdata/scan.star
+++ b/syntax/testdata/scan.star
@@ -22,6 +22,9 @@ from repositories import go_repositories
 from go_repository_module import go_repository, new_go_repository
 from go_prefix_module import go_prefix
 from json_module import json_marshal
+from package import a as aa, b as bb
+import package
+import package as pkg
 
 """These are bare-bones Go rules.
 


### PR DESCRIPTION
## Summary
- update grammar docs for all import statement forms
- expand errors.star and scan.star with examples of all import variants

## Testing
- `./internal/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_68547d8ae854832492fd11110c142619