### PR TITLE
Add Bits bitstring implementation

### DIFF
--- a/starlark/bits.go
+++ b/starlark/bits.go
@@ -1,0 +1,41 @@
+// Copyright 2017
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package starlark
+
+// Bits represents a fixed-size bit string.
+// Its zero value is an empty bit string.
+type Bits struct {
+	bytes []byte
+}
+
+// NewBits returns a new bit string of length n bits.
+func NewBits(n int) *Bits {
+	if n < 0 {
+		panic("negative length")
+	}
+	return &Bits{bytes: make([]byte, (n+7)/8)}
+}
+
+// Set sets the bit i.
+func (b *Bits) Set(i int) {
+	b.bytes[i>>3] |= 1 << uint(i&7)
+}
+
+// Clear clears the bit i.
+func (b *Bits) Clear(i int) {
+	b.bytes[i>>3] &^= 1 << uint(i&7)
+}
+
+// Reset clears all bits in the bit string.
+func (b *Bits) Reset() {
+	for i := range b.bytes {
+		b.bytes[i] = 0
+	}
+}
+
+// Get returns the value of bit i.
+func (b *Bits) Get(i int) bool {
+	return b.bytes[i>>3]&(1<<uint(i&7)) != 0
+}

--- a/starlark/bits_test.go
+++ b/starlark/bits_test.go
@@ -1,0 +1,29 @@
+package starlark
+
+import "testing"
+
+func TestBitsSetClearReset(t *testing.T) {
+	b := NewBits(10)
+	for i := 0; i < 10; i++ {
+		if b.Get(i) {
+			t.Fatalf("bit %d not zero", i)
+		}
+	}
+
+	b.Set(3)
+	b.Set(9)
+	if !b.Get(3) || !b.Get(9) {
+		t.Fatalf("set bits not reported")
+	}
+	b.Clear(3)
+	if b.Get(3) {
+		t.Fatalf("bit not cleared")
+	}
+
+	b.Reset()
+	for i := 0; i < 10; i++ {
+		if b.Get(i) {
+			t.Fatalf("reset failed; bit %d not zero", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add `Bits` type for simple bitstring operations
- test `Bits` set, clear, reset, and get functionality
- remove length storage and index checks from `Bits`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685746bb0c988324939fd82c0a1395c2