### PR TITLE
Add read tracking to programStateDB

### DIFF
--- a/starlark/program_state_db.go
+++ b/starlark/program_state_db.go
@@ -12,8 +12,12 @@ type programStateDB struct {
 	// is per-global blocks so that all versions of a variable are
 	// contiguous.
 	globals []int
+	// Per-statement read set. A value of 0 indicates the variable was not
+	// read by that statement; otherwise it stores the interned value ID that
+	// was read from the variable.
+	readset []int
 	// Intern table of values. Index 0 is reserved to represent "use the
-	// previous value" in globals.
+	// previous value" in globals and to denote "not read" in the read set.
 	values []Value
 }
 
@@ -24,6 +28,7 @@ func newProgramStateDB(numGlobals, numStatements int) *programStateDB {
 		numGlobals:    numGlobals,
 		numStatements: numStatements,
 		globals:       make([]int, numGlobals*numStatements),
+		readset:       make([]int, numGlobals*numStatements),
 		values:        make([]Value, 1), // values[0] unused
 	}
 	return db
@@ -34,6 +39,7 @@ func (db *programStateDB) reset(stmt int) {
 	base := stmt
 	for g := 0; g < db.numGlobals; g++ {
 		db.globals[g*db.numStatements+base] = 0
+		db.readset[g*db.numStatements+base] = 0
 	}
 }
 
@@ -51,8 +57,33 @@ func (db *programStateDB) get(global, stmt int) Value {
 	first := global * db.numStatements
 	for ; i >= first; i-- {
 		if id := db.globals[i]; id != 0 {
+			db.readset[global*db.numStatements+stmt] = id
 			return db.values[id]
 		}
 	}
+	db.readset[global*db.numStatements+stmt] = 0
 	return nil
+}
+
+// reads returns the read set for the specified statement as a slice of
+// (global, valueID) pairs. Only variables that were actually read are
+// included in the result.
+func (db *programStateDB) reads(stmt int) [][2]int {
+	var rs [][2]int
+	base := stmt
+	for g := 0; g < db.numGlobals; g++ {
+		id := db.readset[g*db.numStatements+base]
+		if id != 0 {
+			rs = append(rs, [2]int{g, id})
+		}
+	}
+	return rs
+}
+
+// value returns the interned value for the given id.
+func (db *programStateDB) value(id int) Value {
+	if id <= 0 || id >= len(db.values) {
+		return nil
+	}
+	return db.values[id]
 }

--- a/starlark/program_state_db_test.go
+++ b/starlark/program_state_db_test.go
@@ -11,6 +11,9 @@ func TestProgramStateDB(t *testing.T) {
 
 	// statement 0
 	db.reset(0)
+	if rs := db.reads(0); len(rs) != 0 {
+		t.Fatalf("reads stmt0 after reset = %v, want empty", rs)
+	}
 	db.put(0, 0, String("foo"))
 
 	if got := db.get(0, 0); got != String("foo") {
@@ -19,9 +22,15 @@ func TestProgramStateDB(t *testing.T) {
 	if val := db.get(1, 0); val != nil {
 		t.Fatalf("get g1 stmt0 = %v, want nil", val)
 	}
+	if rs := db.reads(0); len(rs) != 1 || rs[0][0] != 0 || db.value(rs[0][1]) != String("foo") {
+		t.Fatalf("reads stmt0 = %v, want [(0,foo)]", rs)
+	}
 
 	// statement 1
 	db.reset(1)
+	if rs := db.reads(1); len(rs) != 0 {
+		t.Fatalf("reads stmt1 after reset = %v, want empty", rs)
+	}
 	db.put(1, 1, String("bar"))
 
 	if got := db.get(0, 1); got != String("foo") {
@@ -30,9 +39,15 @@ func TestProgramStateDB(t *testing.T) {
 	if got := db.get(1, 1); got != String("bar") {
 		t.Fatalf("get g1 stmt1 = %v, want bar", got)
 	}
+	if rs := db.reads(1); len(rs) != 2 || db.value(rs[0][1]) != String("foo") || db.value(rs[1][1]) != String("bar") {
+		t.Fatalf("reads stmt1 = %v, want two entries foo/bar", rs)
+	}
 
 	// statement 2
 	db.reset(2)
+	if rs := db.reads(2); len(rs) != 0 {
+		t.Fatalf("reads stmt2 after reset = %v, want empty", rs)
+	}
 	db.put(0, 2, String("baz"))
 
 	if got := db.get(0, 2); got != String("baz") {
@@ -40,6 +55,9 @@ func TestProgramStateDB(t *testing.T) {
 	}
 	if got := db.get(1, 2); got != String("bar") {
 		t.Fatalf("get g1 stmt2 = %v, want bar", got)
+	}
+	if rs := db.reads(2); len(rs) != 2 || db.value(rs[0][1]) != String("baz") || db.value(rs[1][1]) != String("bar") {
+		t.Fatalf("reads stmt2 = %v, want two entries baz/bar", rs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- track read sets in `programStateDB`
- expose `reads` and `value` helpers
- extend tests for read set behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858968d3a6083249b8b04ecaff3d288