### PR TITLE
Fix programStateDB read tracking

### DIFF
--- a/starlark/program_state_db.go
+++ b/starlark/program_state_db.go
@@ -72,11 +72,12 @@ func (db *programStateDB) get(global, stmt int) interned {
 	first := global * db.numStatements
 	for ; i >= first; i-- {
 		if id := db.globals[i]; id != 0 {
-			db.readset[global*db.numStatements+stmt] = id
+			if db.readset[global*db.numStatements+stmt] == 0 {
+				db.readset[global*db.numStatements+stmt] = id
+			}
 			return id
 		}
 	}
-	db.readset[global*db.numStatements+stmt] = 0
 	return 0
 }
 

--- a/starlark/program_state_db_test.go
+++ b/starlark/program_state_db_test.go
@@ -75,3 +75,55 @@ func TestProgramStateDBInterning(t *testing.T) {
 		t.Fatalf("got %d interned values, want 4", len(db.values))
 	}
 }
+
+// TestProgramStateDBReadWriteSameGlobal verifies that the readset records the
+// value from the first read of a global even when it is subsequently written
+// and read again within the same statement.
+func TestProgramStateDBReadWriteSameGlobal(t *testing.T) {
+	db := newProgramStateDB(1, 2)
+
+	// statement 0
+	db.reset(0)
+	db.put(0, 0, String("foo"))
+
+	// statement 1
+	db.reset(1)
+
+	if got := db.value(db.get(0, 1)); got != String("foo") {
+		t.Fatalf("first get = %v, want foo", got)
+	}
+
+	db.put(0, 1, String("bar"))
+
+	if got := db.value(db.get(0, 1)); got != String("bar") {
+		t.Fatalf("second get = %v, want bar", got)
+	}
+
+	rs := db.reads(1)
+	if len(rs) != 1 || rs[0].global() != 0 || db.value(rs[0].value()) != String("foo") {
+		t.Fatalf("reads stmt1 = %v, want [(0,foo)]", rs)
+	}
+}
+
+// TestProgramStateDBWriteThenRead verifies that a read that occurs after a
+// write in the same statement records the written value.
+func TestProgramStateDBWriteThenRead(t *testing.T) {
+	db := newProgramStateDB(1, 2)
+
+	// statement 0
+	db.reset(0)
+	db.put(0, 0, String("foo"))
+
+	// statement 1
+	db.reset(1)
+	db.put(0, 1, String("bar"))
+
+	if got := db.value(db.get(0, 1)); got != String("bar") {
+		t.Fatalf("get = %v, want bar", got)
+	}
+
+	rs := db.reads(1)
+	if len(rs) != 1 || rs[0].global() != 0 || db.value(rs[0].value()) != String("bar") {
+		t.Fatalf("reads stmt1 = %v, want [(0,bar)]", rs)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure programStateDB only records the first read of a global in a statement
- cover edge cases when a global is read and written multiple times

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68589fd332688324a76af46a46178b50