### PR TITLE
Track current statement

### DIFF
--- a/internal/compile/codegen_test.go
+++ b/internal/compile/codegen_test.go
@@ -92,6 +92,10 @@ func disassemble(f *Funcode) string {
 			}
 		}
 
+		if op == STATEMENT {
+			continue
+		}
+
 		if out.Len() > 0 {
 			out.WriteString("; ")
 		}

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -68,6 +68,9 @@ type Thread struct {
 
 	// proftime holds the accumulated execution time since the last profile event.
 	proftime time.Duration
+
+	// stmt records the index of the currently executing top-level statement.
+	stmt int
 }
 
 // ExecutionSteps returns the current value of Steps.

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -133,6 +133,9 @@ loop:
 		}
 
 		switch op {
+		case compile.STATEMENT:
+			thread.stmt = int(arg)
+
 		case compile.NOP:
 			// nop
 

--- a/starlark/statement_test.go
+++ b/starlark/statement_test.go
@@ -1,0 +1,18 @@
+package starlark
+
+import "testing"
+
+func TestThreadStatementCounter(t *testing.T) {
+	thread := new(Thread)
+	const src = `
+a = 1
+b = 2
+c = a + b
+`
+	if _, err := ExecFile(thread, "test.star", src, nil); err != nil {
+		t.Fatalf("ExecFile: %v", err)
+	}
+	if thread.stmt != 2 {
+		t.Fatalf("stmt=%d, want 2", thread.stmt)
+	}
+}


### PR DESCRIPTION
## Summary
- add `stmt` field to `Thread`
- introduce `STATEMENT` opcode to update the thread
- mark each statement when compiling top level code
- adjust interpreter to maintain the statement number
- skip STATEMENT in codegen tests and add new test

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858a79c663c8324af12fee2005a2f7a