### PR TITLE
Switch globals to programStateDB

### DIFF
--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -343,6 +343,7 @@ type Funcode struct {
 	NumParams             int
 	NumKwonlyParams       int
 	HasVarargs, HasKwargs bool
+	NumStatements         int // number of STATEMENT opcodes in this function
 
 	// -- transient state --
 
@@ -542,6 +543,7 @@ func (pcomp *pcomp) function(name string, pos syntax.Position, stmts []syntax.St
 	entry := fcomp.newBlock()
 	fcomp.block = entry
 	if topLevel {
+		fcomp.fn.NumStatements = len(stmts)
 		fcomp.stmtsTopLevel(stmts)
 	} else {
 		fcomp.stmts(stmts)

--- a/internal/compile/serial.go
+++ b/internal/compile/serial.go
@@ -45,6 +45,7 @@ package compile
 //	numkwonlyparams	varint
 //	hasvarargs	varint (0 or 1)
 //	haskwargs	varint (0 or 1)
+//      numstatements   varint
 //
 // Ident:
 //	filename	string
@@ -201,6 +202,7 @@ func (e *encoder) function(fn *Funcode) {
 	e.int(fn.NumKwonlyParams)
 	e.int(b2i(fn.HasVarargs))
 	e.int(b2i(fn.HasKwargs))
+	e.int(fn.NumStatements)
 }
 
 func b2i(b bool) int {
@@ -380,6 +382,7 @@ func (d *decoder) function() *Funcode {
 	numKwonlyParams := d.int()
 	hasVarargs := d.int() != 0
 	hasKwargs := d.int() != 0
+	numStatements := d.int()
 	return &Funcode{
 		// Prog is filled in later.
 		Pos:             id.Pos,
@@ -395,5 +398,6 @@ func (d *decoder) function() *Funcode {
 		NumKwonlyParams: numKwonlyParams,
 		HasVarargs:      hasVarargs,
 		HasKwargs:       hasKwargs,
+		NumStatements:   numStatements,
 	}
 }

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -482,7 +482,7 @@ func ExecREPLChunk(f *syntax.File, thread *Thread, globals StringDict) error {
 	// Initialize module globals from parameter.
 	for i, id := range prog.compiled.Globals {
 		if v := globals[id.Name]; v != nil {
-			toplevel.module.globals[i] = v
+			toplevel.module.globals.putInitial(i, v)
 		}
 	}
 
@@ -490,7 +490,7 @@ func ExecREPLChunk(f *syntax.File, thread *Thread, globals StringDict) error {
 
 	// Reflect changes to globals back to parameter, even after an error.
 	for i, id := range prog.compiled.Globals {
-		if v := toplevel.module.globals[i]; v != nil {
+		if v := toplevel.module.globals.getLast(i); v != nil {
 			globals[id.Name] = v
 		}
 	}
@@ -525,7 +525,7 @@ func makeToplevelFunction(prog *compile.Program, predeclared StringDict) *Functi
 		module: &module{
 			program:     prog,
 			predeclared: predeclared,
-			globals:     make([]Value, len(prog.Globals)),
+			globals:     newProgramStateDB(len(prog.Globals), prog.Toplevel.NumStatements),
 			constants:   constants,
 		},
 	}

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -135,6 +135,7 @@ loop:
 		switch op {
 		case compile.STATEMENT:
 			thread.stmt = int(arg)
+			fn.module.globals.reset(int(arg))
 
 		case compile.NOP:
 			// nop
@@ -597,7 +598,7 @@ loop:
 			sp--
 
 		case compile.SETGLOBAL:
-			fn.module.globals[arg] = stack[sp-1]
+			fn.module.globals.put(int(arg), thread.stmt, stack[sp-1])
 			sp--
 
 		case compile.LOCAL:
@@ -632,7 +633,8 @@ loop:
 			sp++
 
 		case compile.GLOBAL:
-			x := fn.module.globals[arg]
+			id := fn.module.globals.get(int(arg), thread.stmt)
+			x := fn.module.globals.value(id)
 			if x == nil {
 				err = fmt.Errorf("global variable %s referenced before assignment", f.Prog.Globals[arg].Name)
 				break loop

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -706,7 +706,7 @@ type Function struct {
 type module struct {
 	program     *compile.Program
 	predeclared StringDict
-	globals     []Value
+	globals     *programStateDB
 	constants   []Value
 }
 
@@ -715,7 +715,7 @@ type module struct {
 func (m *module) makeGlobalDict() StringDict {
 	r := make(StringDict, len(m.program.Globals))
 	for i, id := range m.program.Globals {
-		if v := m.globals[i]; v != nil {
+		if v := m.globals.getLast(i); v != nil {
 			r[id.Name] = v
 		}
 	}


### PR DESCRIPTION
## Summary
- add NumStatements field to Funcode
- track globals using programStateDB instead of []Value
- update interpreter SETGLOBAL/GLOBAL/STATEMENT
- support initial global values for REPL chunks
- encode/decode NumStatements in bytecode

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858cd9c0da483248ec4404b3da10baa