### PR TITLE
Unify observed globals in cache

### DIFF
--- a/starlark/program_state_db_test.go
+++ b/starlark/program_state_db_test.go
@@ -41,9 +41,11 @@ func TestProgramStateDBPutGet(t *testing.T) {
 	db := NewProgramStateDB()
 	arg := db.Intern(MakeInt(dynamicInt(42)))
 	res := db.Intern(String("result"))
-	reads := []Read{{variable: 1, value: arg}}
-	writes := []Write{{variable: 2, value: res}}
-	db.Put(1, []Interned{arg}, reads, writes, res)
+	captures := []Capture{
+		{variable: 1, value: arg},
+		{variable: 2, value: res},
+	}
+	db.Put(1, []Interned{arg}, captures, res)
 	rec := db.Get(1, []Interned{arg})
 	if rec == nil {
 		t.Fatalf("expected record to be found")
@@ -51,11 +53,9 @@ func TestProgramStateDBPutGet(t *testing.T) {
 	if !rec.result.Eq(res) || rec.function != 1 || len(rec.args) != 1 || !rec.args[0].Eq(arg) {
 		t.Fatalf("record mismatch")
 	}
-	if len(rec.reads) != 1 || rec.reads[0].variable != 1 || !rec.reads[0].value.Eq(arg) {
-		t.Fatalf("reads mismatch")
-	}
-	if len(rec.writes) != 1 || rec.writes[0].variable != 2 || !rec.writes[0].value.Eq(res) {
-		t.Fatalf("writes mismatch")
+	if len(rec.captures) != 2 || rec.captures[0].variable != 1 || !rec.captures[0].value.Eq(arg) ||
+		rec.captures[1].variable != 2 || !rec.captures[1].value.Eq(res) {
+		t.Fatalf("captures mismatch")
 	}
 
 	// request with different arg should miss
@@ -69,7 +69,7 @@ func TestProgramStateDBCollision(t *testing.T) {
 	db := NewProgramStateDB()
 	arg := db.Intern(MakeInt(dynamicInt(1)))
 	r1 := db.Intern(String("one"))
-	db.Put(0, []Interned{arg}, nil, nil, r1)
+	db.Put(0, []Interned{arg}, nil, r1)
 
 	// find a second function id that hashes to the same slot
 	target := hashKey(0, []Interned{arg})
@@ -83,7 +83,7 @@ func TestProgramStateDBCollision(t *testing.T) {
 		t.Fatalf("unable to find collision")
 	}
 	r2 := db.Intern(String("two"))
-	db.Put(fid2, []Interned{arg}, nil, nil, r2)
+	db.Put(fid2, []Interned{arg}, nil, r2)
 
 	// first record should be evicted
 	if rec := db.Get(0, []Interned{arg}); rec != nil {


### PR DESCRIPTION
## Summary
- rename global observation tracking structures from `globals` to `captures`
- update interpreter and cache DB for new naming
- adjust tests for renamed API

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685cd71b048c8324b565c3ba30cb7799