### PR TITLE
Move ProgramStateDB to thread

### DIFF
--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -66,6 +66,9 @@ type Thread struct {
 	// They are accessible to the client but not to any Starlark program.
 	locals map[string]interface{}
 
+	// cache stores state for function call memoization.
+	cache *ProgramStateDB
+
 	// proftime holds the accumulated execution time since the last profile event.
 	proftime time.Duration
 }
@@ -525,7 +528,6 @@ func makeToplevelFunction(prog *compile.Program, predeclared StringDict) *Functi
 			predeclared: predeclared,
 			globals:     make([]Value, len(prog.Globals)),
 			constants:   constants,
-			cache:       NewProgramStateDB(),
 		},
 	}
 }

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -60,7 +60,10 @@ func (fn *Function) CallInternal(thread *Thread, args Tuple, kwargs []Tuple) (Va
 		return nil, thread.evalError(err)
 	}
 
-	cache := fn.module.cache
+	if thread.cache == nil {
+		thread.cache = NewProgramStateDB()
+	}
+	cache := thread.cache
 	snapshot := cache.version
 	internedArgs := make([]Interned, fn.NumParams())
 	for i := range internedArgs {

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -709,7 +709,6 @@ type module struct {
 	predeclared StringDict
 	globals     []Value
 	constants   []Value
-	cache       *ProgramStateDB
 }
 
 // makeGlobalDict returns a new, unfrozen StringDict containing all global


### PR DESCRIPTION
## Summary
- store ProgramStateDB on `Thread`
- drop cache field from module
- ensure cache is initialised when calling a function
- remove redundant cache initialisation in `Call`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685de8d493848324811cf56d2b1a1289