### PR TITLE
Update Cmp signatures to accept thread

### DIFF
--- a/lib/time/time.go
+++ b/lib/time/time.go
@@ -242,7 +242,7 @@ func (d Duration) AttrNames() []string {
 
 // Cmp implements comparison of two Duration values. required by
 // starlark.TotallyOrdered interface.
-func (d Duration) Cmp(v starlark.Value, depth int) (int, error) {
+func (d Duration) Cmp(thread *starlark.Thread, v starlark.Value, depth int) (int, error) {
 	if x, y := d, v.(Duration); x < y {
 		return -1, nil
 	} else if x > y {
@@ -426,7 +426,7 @@ func (t Time) AttrNames() []string {
 
 // Cmp implements comparison of two Time values. Required by
 // starlark.TotallyOrdered interface.
-func (t Time) Cmp(yV starlark.Value, depth int) (int, error) {
+func (t Time) Cmp(thread *starlark.Thread, yV starlark.Value, depth int) (int, error) {
 	x := time.Time(t)
 	y := time.Time(yV.(Time))
 	if x.Before(y) {

--- a/starlark/int.go
+++ b/starlark/int.go
@@ -193,7 +193,7 @@ func (i Int) Hash() (uint32, error) {
 
 // Cmp implements comparison of two Int values.
 // Required by the TotallyOrdered interface.
-func (i Int) Cmp(v Value, depth int) (int, error) {
+func (i Int) Cmp(thread *Thread, v Value, depth int) (int, error) {
 	j := v.(Int)
 	iSmall, iBig := i.get()
 	jSmall, jBig := j.get()

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -162,7 +162,7 @@ type TotallyOrdered interface {
 	// Client code should not call this method.  Instead, use the
 	// standalone Compare or Equals functions, which are defined for
 	// all pairs of operands.
-	Cmp(y Value, depth int) (int, error)
+	Cmp(thread *Thread, y Value, depth int) (int, error)
 }
 
 var (
@@ -482,7 +482,7 @@ func isFinite(f float64) bool {
 
 // Cmp implements comparison of two Float values.
 // Required by the TotallyOrdered interface.
-func (f Float) Cmp(v Value, depth int) (int, error) {
+func (f Float) Cmp(thread *Thread, v Value, depth int) (int, error) {
 	g := v.(Float)
 	return floatCmp(f, g), nil
 }
@@ -1487,7 +1487,7 @@ func CompareDepth(op syntax.Token, x, y Value, depth int) (bool, error) {
 		}
 
 		if xcomp, ok := x.(TotallyOrdered); ok {
-			t, err := xcomp.Cmp(y, depth)
+			t, err := xcomp.Cmp(NilThreadPlaceholder(), y, depth)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
## Summary
- add thread to the `TotallyOrdered` interface's `Cmp` method
- update implementations in `Int`, `Float`, `Duration`, and `Time`
- update comparison logic to pass `NilThreadPlaceholder()` when calling `Cmp`

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6860884f9f488324a1293b43578b8f71