### PR TITLE
Update Items signature to accept thread

### DIFF
--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -156,7 +156,7 @@ func encode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 		case starlark.IterableMapping:
 			// e.g. dict (must have string keys)
 			buf.WriteByte('{')
-			items := x.Items()
+			items := x.Items(starlark.NilThreadPlaceholder())
 			for _, item := range items {
 				if _, ok := item[0].(starlark.String); !ok {
 					return fmt.Errorf("%s has %s key, want string", x.Type(), item[0].Type())

--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -356,7 +356,7 @@ func (d MessageDescriptor) CallInternal(thread *starlark.Thread, args starlark.T
 			return dest, nil
 
 		case *starlark.Dict:
-			kwargs = src.Items()
+			kwargs = src.Items(starlark.NilThreadPlaceholder())
 			// fall through
 
 		default:
@@ -582,7 +582,7 @@ func toProto(fdesc protoreflect.FieldDescriptor, v starlark.Value) (protoreflect
 
 		case *starlark.Dict:
 			dest := newMessage(desc)
-			err := setFields(dest, v.Items())
+			err := setFields(dest, v.Items(starlark.NilThreadPlaceholder()))
 			return protoreflect.ValueOfMessage(dest), err
 		}
 
@@ -1162,7 +1162,7 @@ func (mf *MapField) Iterate() starlark.Iterator {
 }
 
 // Items returns a slice of key-value pairs, sorted in key order.
-func (mf *MapField) Items() []starlark.Tuple {
+func (mf *MapField) Items(thread *starlark.Thread) []starlark.Tuple {
 	out := make([]starlark.Tuple, 0, mf.mp.Len())
 	array := make([]starlark.Value, 2*mf.mp.Len()) // allocate a single backing array
 
@@ -1197,7 +1197,7 @@ func (mf *MapField) String() string {
 	buf := new(strings.Builder)
 	buf.WriteByte('{')
 
-	for i, kv := range mf.Items() {
+	for i, kv := range mf.Items(starlark.NilThreadPlaceholder()) {
 		if i > 0 {
 			buf.WriteString(", ")
 		}

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -333,7 +333,7 @@ loop:
 					err = fmt.Errorf("argument after ** must be a mapping, not %s", kwargs.Type())
 					break loop
 				}
-				items := dict.Items()
+				items := dict.Items(NilThreadPlaceholder())
 				for _, item := range items {
 					if _, ok := item[0].(String); !ok {
 						err = fmt.Errorf("keywords must be strings, not %s", item[0].Type())

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -1230,7 +1230,7 @@ func dict_items(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	items := b.Receiver().(*Dict).Items()
+	items := b.Receiver().(*Dict).Items(NilThreadPlaceholder())
 	res := make([]Value, len(items))
 	for i, item := range items {
 		res[i] = item // convert [2]Value to Value
@@ -1313,7 +1313,7 @@ func dict_values(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0); err != nil {
 		return nil, err
 	}
-	items := b.Receiver().(*Dict).Items()
+	items := b.Receiver().(*Dict).Items(NilThreadPlaceholder())
 	res := make([]Value, len(items))
 	for i, item := range items {
 		res[i] = item[1]
@@ -2415,7 +2415,7 @@ func updateDict(dict *Dict, updates Tuple, kwargs []Tuple) error {
 		switch updates := updates[0].(type) {
 		case IterableMapping:
 			// Iterate over dict's key/value pairs, not just keys.
-			for _, item := range updates.Items() {
+			for _, item := range updates.Items(NilThreadPlaceholder()) {
 				if err := dict.SetKey(item[0], item[1]); err != nil {
 					return err // dict is frozen
 				}

--- a/starlark/value.go
+++ b/starlark/value.go
@@ -300,8 +300,8 @@ type Mapping interface {
 // See [Entries] for example use.
 type IterableMapping interface {
 	Mapping
-	Iterate() Iterator // see Iterable interface
-	Items() []Tuple    // a new slice containing all key/value pairs
+	Iterate() Iterator            // see Iterable interface
+	Items(thread *Thread) []Tuple // a new slice containing all key/value pairs
 }
 
 var _ IterableMapping = (*Dict)(nil)
@@ -870,7 +870,7 @@ func NewDict(size int) *Dict {
 func (d *Dict) Clear() error                                    { return d.ht.clear() }
 func (d *Dict) Delete(k Value) (v Value, found bool, err error) { return d.ht.delete(k) }
 func (d *Dict) Get(k Value) (v Value, found bool, err error)    { return d.ht.lookup(k) }
-func (d *Dict) Items() []Tuple                                  { return d.ht.items() }
+func (d *Dict) Items(thread *Thread) []Tuple                    { return d.ht.items() }
 func (d *Dict) Keys() []Value                                   { return d.ht.keys() }
 func (d *Dict) Len() int                                        { return int(d.ht.len) }
 func (d *Dict) Iterate() Iterator                               { return d.ht.iterate() }


### PR DESCRIPTION
## Summary
- extend `IterableMapping.Items` to accept `thread *Thread`
- propagate new parameter to `Dict` and `MapField`
- update call sites with `NilThreadPlaceholder()` as the argument

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6860886f247483249b628a3f60c3f0eb