### PR TITLE
Add thread parameter to Mapping.Get methods

### DIFF
--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -447,7 +447,7 @@ func setField(msg protoreflect.Message, fdesc protoreflect.FieldDescriptor, valu
 			// iterator guarantees the presence of some value (even if it is
 			// starlark.None). Mismatching values will be caught in toProto
 			// below.
-			v, _, err := mapping.Get(k)
+			v, _, err := mapping.Get(starlark.NilThreadPlaceholder(), k)
 			if err != nil {
 				return fmt.Errorf("in map field %s, at key %s: %w", fdesc.Name(), k.String(), err)
 			}
@@ -1123,7 +1123,7 @@ func (mf *MapField) checkMutable(verb string) error {
 	return nil
 }
 
-func (mf *MapField) Get(k starlark.Value) (starlark.Value, bool, error) {
+func (mf *MapField) Get(thread *starlark.Thread, k starlark.Value) (starlark.Value, bool, error) {
 	if err := mf.checkKeyType(); err != nil {
 		return nil, false, err
 	}

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -691,7 +691,7 @@ func setField(x Value, name string, y Value) error {
 func getIndex(thread *Thread, x, y Value) (Value, error) {
 	switch x := x.(type) {
 	case Mapping: // dict
-		z, found, err := x.Get(y)
+		z, found, err := x.Get(NilThreadPlaceholder(), y)
 		if err != nil {
 			return nil, err
 		}
@@ -1070,7 +1070,7 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 		case Mapping: // e.g. dict
 			// Ignore error from Get as we cannot distinguish true
 			// errors (value cycle, type error) from "key not found".
-			_, found, _ := y.Get(x)
+			_, found, _ := y.Get(NilThreadPlaceholder(), x)
 			return Bool(found), nil
 		case *Set:
 			ok, err := y.Has(x)
@@ -1604,7 +1604,7 @@ func interpolate(format string, x Value) (Value, error) {
 			key := format[:j]
 			if dict, ok := x.(Mapping); !ok {
 				return nil, fmt.Errorf("format requires a mapping")
-			} else if v, found, _ := dict.Get(String(key)); found {
+			} else if v, found, _ := dict.Get(NilThreadPlaceholder(), String(key)); found {
 				arg = v
 			} else {
 				return nil, fmt.Errorf("key not found: %s", key)

--- a/starlark/iter.go
+++ b/starlark/iter.go
@@ -105,7 +105,7 @@ func Entries(mapping IterableMapping) iter.Seq2[Value, Value] {
 		defer iter.Done()
 		var k Value
 		for iter.Next(&k) {
-			v, found, err := mapping.Get(k)
+			v, found, err := mapping.Get(NilThreadPlaceholder(), k)
 			if err != nil || !found {
 				panic(fmt.Sprintf("Iterate and Get are inconsistent (mapping=%v, key=%v)",
 					mapping.Type(), k.Type()))

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -1207,7 +1207,7 @@ func dict_get(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &key, &dflt); err != nil {
 		return nil, err
 	}
-	if v, ok, err := b.Receiver().(*Dict).Get(key); err != nil {
+	if v, ok, err := b.Receiver().(*Dict).Get(NilThreadPlaceholder(), key); err != nil {
 		return nil, nameErr(b, err)
 	} else if ok {
 		return v, nil
@@ -1286,7 +1286,7 @@ func dict_setdefault(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, 
 		return nil, err
 	}
 	dict := b.Receiver().(*Dict)
-	if v, ok, err := dict.Get(key); err != nil {
+	if v, ok, err := dict.Get(NilThreadPlaceholder(), key); err != nil {
 		return nil, nameErr(b, err)
 	} else if ok {
 		return v, nil


### PR DESCRIPTION
## Summary
- expand `Mapping` interface `Get` method to accept `thread *Thread`
- update `Dict` and `MapField` implementations
- fix all call sites using `NilThreadPlaceholder()`

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6860886b26e483249732a928e18d7533