### PR TITLE
Add thread param to Index

### DIFF
--- a/lib/proto/iter.go
+++ b/lib/proto/iter.go
@@ -12,11 +12,11 @@ import (
 // Elements returns a go1.23 iterator over the values of a repeated field.
 // For example:
 //
-//   for val := range repeatedField.Elements() { ... }
+//	for val := range repeatedField.Elements() { ... }
 func (rf *RepeatedField) Elements() iter.Seq[starlark.Value] {
 	return func(yield func(starlark.Value) bool) {
 		for i := range rf.list.Len() {
-			if !yield(rf.Index(i)) {
+			if !yield(rf.Index(starlark.NilThreadPlaceholder(), i)) {
 				return
 			}
 		}
@@ -26,7 +26,7 @@ func (rf *RepeatedField) Elements() iter.Seq[starlark.Value] {
 // Entries returns a go1.23 iterator over the values of a map field. For
 // example:
 //
-//   for k, v := range mapField.Entries() { ... }
+//	for k, v := range mapField.Entries() { ... }
 func (mf *MapField) Entries() iter.Seq2[starlark.Value, starlark.Value] {
 	return func(yield func(k, v starlark.Value) bool) {
 		mf.mp.Range(func(mk protoreflect.MapKey, v protoreflect.Value) bool {

--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -1010,7 +1010,7 @@ func (rf *RepeatedField) checkMutable(verb string) error {
 
 func (rf *RepeatedField) Freeze()               { *rf.frozen = true }
 func (rf *RepeatedField) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: %s", rf.Type()) }
-func (rf *RepeatedField) Index(i int) starlark.Value {
+func (rf *RepeatedField) Index(thread *starlark.Thread, i int) starlark.Value {
 	return toStarlark1(rf.typ, rf.list.Get(i), rf.frozen)
 }
 func (rf *RepeatedField) Iterate() starlark.Iterator {
@@ -1042,7 +1042,7 @@ type repeatedFieldIterator struct {
 
 func (it *repeatedFieldIterator) Next(p *starlark.Value) bool {
 	if it.i < it.rf.Len() {
-		*p = it.rf.Index(it.i)
+		*p = it.rf.Index(starlark.NilThreadPlaceholder(), it.i)
 		it.i++
 		return true
 	}

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -716,7 +716,7 @@ func getIndex(thread *Thread, x, y Value) (Value, error) {
 		if tlist, ok := x.(*List); ok && thread != nil {
 			thread.readList(tlist)
 		}
-		return x.Index(i), nil
+		return x.Index(thread, i), nil
 	}
 	return nil, fmt.Errorf("unhandled index operation %s[%s]", x.Type(), y.Type())
 }

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -1151,7 +1151,7 @@ f(1)
 	if err != nil {
 		t.Fatalf("ExecFile returned error %q, expected panic", err)
 	}
-	got := m["e"].(*starlark.List).Index(0).String()
+	got := m["e"].(*starlark.List).Index(starlark.NilThreadPlaceholder(), 0).String()
 	want := `{"q": 2, "inner": 4, "outer": 3}`
 	if got != want {
 		t.Errorf("env() returned %s, want %s", got, want)

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -856,9 +856,9 @@ var (
 	_ Sliceable  = rangeValue{}
 )
 
-func (r rangeValue) Len() int          { return r.len }
-func (r rangeValue) Index(i int) Value { return MakeInt(r.start + i*r.step) }
-func (r rangeValue) Iterate() Iterator { return &rangeIterator{r, 0} }
+func (r rangeValue) Len() int                          { return r.len }
+func (r rangeValue) Index(thread *Thread, i int) Value { return MakeInt(r.start + i*r.step) }
+func (r rangeValue) Iterate() Iterator                 { return &rangeIterator{r, 0} }
 
 // rangeLen calculates the length of a range with the provided start, stop, and step.
 // caller must ensure that step is non-zero.
@@ -947,7 +947,7 @@ type rangeIterator struct {
 
 func (it *rangeIterator) Next(p *Value) bool {
 	if it.i < it.r.len {
-		*p = it.r.Index(it.i)
+		*p = it.r.Index(NilThreadPlaceholder(), it.i)
 		it.i++
 		return true
 	}

--- a/starlark/value_test.go
+++ b/starlark/value_test.go
@@ -37,9 +37,9 @@ func TestStringMethod(t *testing.T) {
 func TestListAppend(t *testing.T) {
 	l := starlark.NewList(nil)
 	l.Append(&starlark.Thread{}, starlark.String("hello"))
-	res, ok := starlark.AsString(l.Index(0))
+	res, ok := starlark.AsString(l.Index(starlark.NilThreadPlaceholder(), 0))
 	if !ok {
-		t.Errorf("failed list.Append() got: %s, want: starlark.String", l.Index(0).Type())
+		t.Errorf("failed list.Append() got: %s, want: starlark.String", l.Index(starlark.NilThreadPlaceholder(), 0).Type())
 	}
 	if res != "hello" {
 		t.Errorf("failed list.Append() got: %+v, want: hello", res)


### PR DESCRIPTION
## Summary
- add `thread` argument to `Indexable.Index`
- update implementations in `starlark`, `proto`, and library code
- fix all call sites by using `NilThreadPlaceholder()`

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6860885d77a483249f2df7d5eebd6f69