### PR TITLE
Add thread param to Iterate methods

### DIFF
--- a/lib/json/json.go
+++ b/lib/json/json.go
@@ -181,7 +181,7 @@ func encode(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, k
 		case starlark.Iterable:
 			// e.g. tuple, list
 			buf.WriteByte('[')
-			iter := x.Iterate()
+			iter := x.Iterate(starlark.NilThreadPlaceholder())
 			defer iter.Done()
 			var elem starlark.Value
 			for i := 0; iter.Next(&elem); i++ {

--- a/lib/proto/proto.go
+++ b/lib/proto/proto.go
@@ -404,7 +404,7 @@ func setField(msg protoreflect.Message, fdesc protoreflect.FieldDescriptor, valu
 	//  x = []; msg.x = x; y = msg.x
 	// causes x and y not to alias.
 	if fdesc.IsList() {
-		iter := starlark.Iterate(value)
+		iter := starlark.Iterate(starlark.NilThreadPlaceholder(), value)
 		if iter == nil {
 			return fmt.Errorf("got %s for .%s field, want iterable", value.Type(), fdesc.Name())
 		}
@@ -429,7 +429,7 @@ func setField(msg protoreflect.Message, fdesc protoreflect.FieldDescriptor, valu
 			return fmt.Errorf("in map field %s: expected mappable type, but got %s", fdesc.Name(), value.Type())
 		}
 
-		iter := mapping.Iterate()
+		iter := mapping.Iterate(starlark.NilThreadPlaceholder())
 		defer iter.Done()
 
 		// Each value is converted using toProto as usual, passing the key/value
@@ -1013,7 +1013,7 @@ func (rf *RepeatedField) Hash() (uint32, error) { return 0, fmt.Errorf("unhashab
 func (rf *RepeatedField) Index(i int) starlark.Value {
 	return toStarlark1(rf.typ, rf.list.Get(i), rf.frozen)
 }
-func (rf *RepeatedField) Iterate() starlark.Iterator {
+func (rf *RepeatedField) Iterate(thread *starlark.Thread) starlark.Iterator {
 	if !*rf.frozen {
 		rf.itercount++
 	}
@@ -1143,7 +1143,7 @@ func (mf *MapField) Get(k starlark.Value) (starlark.Value, bool, error) {
 func (mf *MapField) Freeze()               { *mf.frozen = true }
 func (mf *MapField) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: %s", mf.Type()) }
 
-func (mf *MapField) Iterate() starlark.Iterator {
+func (mf *MapField) Iterate(thread *starlark.Thread) starlark.Iterator {
 	if !*mf.frozen {
 		mf.itercount++
 	}

--- a/starlark/eval.go
+++ b/starlark/eval.go
@@ -633,7 +633,7 @@ func listExtend(thread *Thread, x *List, y Iterable) {
 		x.elems = append(x.elems, ylist.elems...)
 	} else {
 		thread.writeList(x)
-		iter := y.Iterate()
+		iter := y.Iterate(NilThreadPlaceholder())
 		defer iter.Done()
 		var z Value
 		for iter.Next(&z) {
@@ -855,7 +855,7 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			}
 		case *Set: // difference
 			if y, ok := y.(*Set); ok {
-				iter := y.Iterate()
+				iter := y.Iterate(NilThreadPlaceholder())
 				defer iter.Done()
 				return x.Difference(iter)
 			}
@@ -1116,7 +1116,7 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 
 		case *Set: // union
 			if y, ok := y.(*Set); ok {
-				iter := Iterate(y)
+				iter := Iterate(NilThreadPlaceholder(), y)
 				defer iter.Done()
 				return x.Union(iter)
 			}
@@ -1130,7 +1130,7 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			}
 		case *Set: // intersection
 			if y, ok := y.(*Set); ok {
-				iter := y.Iterate()
+				iter := y.Iterate(NilThreadPlaceholder())
 				defer iter.Done()
 				return x.Intersection(iter)
 			}
@@ -1144,7 +1144,7 @@ func Binary(op syntax.Token, x, y Value) (Value, error) {
 			}
 		case *Set: // symmetric difference
 			if y, ok := y.(*Set); ok {
-				iter := y.Iterate()
+				iter := y.Iterate(NilThreadPlaceholder())
 				defer iter.Done()
 				return x.SymmetricDifference(iter)
 			}

--- a/starlark/eval_test.go
+++ b/starlark/eval_test.go
@@ -197,12 +197,12 @@ func TestExecFile(t *testing.T) {
 // A fib is an iterable value representing the infinite Fibonacci sequence.
 type fib struct{}
 
-func (t fib) Freeze()                    {}
-func (t fib) String() string             { return "fib" }
-func (t fib) Type() string               { return "fib" }
-func (t fib) Truth() starlark.Bool       { return true }
-func (t fib) Hash() (uint32, error)      { return 0, fmt.Errorf("fib is unhashable") }
-func (t fib) Iterate() starlark.Iterator { return &fibIterator{0, 1} }
+func (t fib) Freeze()                                           {}
+func (t fib) String() string                                    { return "fib" }
+func (t fib) Type() string                                      { return "fib" }
+func (t fib) Truth() starlark.Bool                              { return true }
+func (t fib) Hash() (uint32, error)                             { return 0, fmt.Errorf("fib is unhashable") }
+func (t fib) Iterate(thread *starlark.Thread) starlark.Iterator { return &fibIterator{0, 1} }
 
 type fibIterator struct{ x, y int }
 

--- a/starlark/hashtable_test.go
+++ b/starlark/hashtable_test.go
@@ -131,7 +131,7 @@ func TestHashtableCount(t *testing.T) {
 		ht.insert(MakeInt(i), None)
 	}
 
-	if c, err := ht.count(rangeValue{0, count, 1, count}.Iterate()); err != nil {
+	if c, err := ht.count(rangeValue{0, count, 1, count}.Iterate(NilThreadPlaceholder())); err != nil {
 		t.Error(err)
 	} else if c != count {
 		t.Errorf("count doesn't match: expected %d got %d", count, c)

--- a/starlark/interp.go
+++ b/starlark/interp.go
@@ -362,7 +362,7 @@ loop:
 			}
 			if args != nil {
 				// Add elements from *args sequence.
-				iter := Iterate(args)
+				iter := Iterate(NilThreadPlaceholder(), args)
 				if iter == nil {
 					err = fmt.Errorf("argument after * must be iterable, not %s", args.Type())
 					break loop
@@ -396,7 +396,7 @@ loop:
 		case compile.ITERPUSH:
 			x := stack[sp-1]
 			sp--
-			iter := Iterate(x)
+			iter := Iterate(NilThreadPlaceholder(), x)
 			if iter == nil {
 				err = fmt.Errorf("%s value is not iterable", x.Type())
 				break loop
@@ -510,7 +510,7 @@ loop:
 			n := int(arg)
 			iterable := stack[sp-1]
 			sp--
-			iter := Iterate(iterable)
+			iter := Iterate(NilThreadPlaceholder(), iterable)
 			if iter == nil {
 				err = fmt.Errorf("got %s in sequence assignment", iterable.Type())
 				break loop

--- a/starlark/iter.go
+++ b/starlark/iter.go
@@ -71,7 +71,7 @@ func Elements(iterable Iterable) iter.Seq[Value] {
 		return iterable.Elements()
 	}
 
-	iter := iterable.Iterate()
+	iter := iterable.Iterate(NilThreadPlaceholder())
 	return func(yield func(Value) bool) {
 		defer iter.Done()
 		var x Value
@@ -100,7 +100,7 @@ func Entries(mapping IterableMapping) iter.Seq2[Value, Value] {
 		return mapping.Entries()
 	}
 
-	iter := mapping.Iterate()
+	iter := mapping.Iterate(NilThreadPlaceholder())
 	return func(yield func(k, v Value) bool) {
 		defer iter.Done()
 		var k Value

--- a/starlark/library.go
+++ b/starlark/library.go
@@ -199,7 +199,7 @@ func all(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 	if err := UnpackPositionalArgs("all", args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
-	iter := iterable.Iterate()
+	iter := iterable.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	var x Value
 	for iter.Next(&x) {
@@ -216,7 +216,7 @@ func any_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 	if err := UnpackPositionalArgs("any", args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
-	iter := iterable.Iterate()
+	iter := iterable.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	var x Value
 	for iter.Next(&x) {
@@ -257,7 +257,7 @@ func bytes_(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 			// common case: known length
 			buf.Grow(n)
 		}
-		iter := x.Iterate()
+		iter := x.Iterate(NilThreadPlaceholder())
 		defer iter.Done()
 		var elem Value
 		var b byte
@@ -337,7 +337,7 @@ func enumerate(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, e
 		return nil, err
 	}
 
-	iter := iterable.Iterate()
+	iter := iterable.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 
 	var pairs []Value
@@ -684,7 +684,7 @@ func list(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error)
 	}
 	var elems []Value
 	if iterable != nil {
-		iter := iterable.Iterate()
+		iter := iterable.Iterate(NilThreadPlaceholder())
 		defer iter.Done()
 		if n := Len(iterable); n > 0 {
 			elems = make([]Value, 0, n) // preallocate if length known
@@ -718,7 +718,7 @@ func minmax(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 	} else {
 		iterable = args
 	}
-	iter := Iterate(iterable)
+	iter := Iterate(NilThreadPlaceholder(), iterable)
 	if iter == nil {
 		return nil, fmt.Errorf("%s: %s value is not iterable", b.Name(), iterable.Type())
 	}
@@ -856,9 +856,9 @@ var (
 	_ Sliceable  = rangeValue{}
 )
 
-func (r rangeValue) Len() int          { return r.len }
-func (r rangeValue) Index(i int) Value { return MakeInt(r.start + i*r.step) }
-func (r rangeValue) Iterate() Iterator { return &rangeIterator{r, 0} }
+func (r rangeValue) Len() int                        { return r.len }
+func (r rangeValue) Index(i int) Value               { return MakeInt(r.start + i*r.step) }
+func (r rangeValue) Iterate(thread *Thread) Iterator { return &rangeIterator{r, 0} }
 
 // rangeLen calculates the length of a range with the provided start, stop, and step.
 // caller must ensure that step is non-zero.
@@ -970,7 +970,7 @@ func reversed(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, er
 	if err := UnpackPositionalArgs("reversed", args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
-	iter := iterable.Iterate()
+	iter := iterable.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	var elems []Value
 	if n := Len(args[0]); n >= 0 {
@@ -995,7 +995,7 @@ func set(thread *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 	}
 	set := new(Set)
 	if iterable != nil {
-		iter := iterable.Iterate()
+		iter := iterable.Iterate(NilThreadPlaceholder())
 		defer iter.Done()
 		var x Value
 		for iter.Next(&x) {
@@ -1021,7 +1021,7 @@ func sorted(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 		return nil, err
 	}
 
-	iter := iterable.Iterate()
+	iter := iterable.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	var values []Value
 	if n := Len(iterable); n > 0 {
@@ -1121,7 +1121,7 @@ func tuple(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error
 	if len(args) == 0 {
 		return Tuple(nil), nil
 	}
-	iter := iterable.Iterate()
+	iter := iterable.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	var elems Tuple
 	if n := Len(iterable); n > 0 {
@@ -1160,7 +1160,7 @@ func zip(thread *Thread, _ *Builtin, args Tuple, kwargs []Tuple) (Value, error) 
 		}
 	}()
 	for i, seq := range args {
-		it := Iterate(seq)
+		it := Iterate(NilThreadPlaceholder(), seq)
 		if it == nil {
 			return nil, fmt.Errorf("zip: argument #%d is not iterable: %s", i+1, seq.Type())
 		}
@@ -1522,12 +1522,12 @@ type bytesIterable struct{ bytes Bytes }
 
 var _ Iterable = (*bytesIterable)(nil)
 
-func (bi bytesIterable) String() string        { return bi.bytes.String() + ".elems()" }
-func (bi bytesIterable) Type() string          { return "bytes.elems" }
-func (bi bytesIterable) Freeze()               {} // immutable
-func (bi bytesIterable) Truth() Bool           { return True }
-func (bi bytesIterable) Hash() (uint32, error) { return 0, fmt.Errorf("unhashable: %s", bi.Type()) }
-func (bi bytesIterable) Iterate() Iterator     { return &bytesIterator{bi.bytes} }
+func (bi bytesIterable) String() string                  { return bi.bytes.String() + ".elems()" }
+func (bi bytesIterable) Type() string                    { return "bytes.elems" }
+func (bi bytesIterable) Freeze()                         {} // immutable
+func (bi bytesIterable) Truth() Bool                     { return True }
+func (bi bytesIterable) Hash() (uint32, error)           { return 0, fmt.Errorf("unhashable: %s", bi.Type()) }
+func (bi bytesIterable) Iterate(thread *Thread) Iterator { return &bytesIterator{bi.bytes} }
 
 type bytesIterator struct{ bytes Bytes }
 
@@ -1859,7 +1859,7 @@ func string_join(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, erro
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 1, &iterable); err != nil {
 		return nil, err
 	}
-	iter := iterable.Iterate()
+	iter := iterable.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	buf := new(strings.Builder)
 	var x Value
@@ -2234,7 +2234,7 @@ func set_difference(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
-	iter := other.Iterate()
+	iter := other.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	diff, err := b.Receiver().(*Set).Difference(iter)
 	if err != nil {
@@ -2250,7 +2250,7 @@ func set_intersection(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value,
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
-	iter := other.Iterate()
+	iter := other.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	diff, err := b.Receiver().(*Set).Intersection(iter)
 	if err != nil {
@@ -2265,7 +2265,7 @@ func set_issubset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, err
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
-	iter := other.Iterate()
+	iter := other.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	diff, err := b.Receiver().(*Set).IsSubset(iter)
 	if err != nil {
@@ -2280,7 +2280,7 @@ func set_issuperset(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple) (Value, e
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
-	iter := other.Iterate()
+	iter := other.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	diff, err := b.Receiver().(*Set).IsSuperset(iter)
 	if err != nil {
@@ -2349,7 +2349,7 @@ func set_symmetric_difference(_ *Thread, b *Builtin, args Tuple, kwargs []Tuple)
 	if err := UnpackPositionalArgs(b.Name(), args, kwargs, 0, &other); err != nil {
 		return nil, err
 	}
-	iter := other.Iterate()
+	iter := other.Iterate(NilThreadPlaceholder())
 	defer iter.Done()
 	diff, err := b.Receiver().(*Set).SymmetricDifference(iter)
 	if err != nil {
@@ -2422,14 +2422,14 @@ func updateDict(dict *Dict, updates Tuple, kwargs []Tuple) error {
 			}
 		default:
 			// all other sequences
-			iter := Iterate(updates)
+			iter := Iterate(NilThreadPlaceholder(), updates)
 			if iter == nil {
 				return fmt.Errorf("got %s, want iterable", updates.Type())
 			}
 			defer iter.Done()
 			var pair Value
 			for i := 0; iter.Next(&pair); i++ {
-				iter2 := Iterate(pair)
+				iter2 := Iterate(NilThreadPlaceholder(), pair)
 				if iter2 == nil {
 					return fmt.Errorf("dictionary update sequence element #%d is not iterable (%s)", i, pair.Type())
 
@@ -2485,7 +2485,7 @@ func setUpdate(s *Set, args Tuple, kwargs []Tuple) error {
 			return fmt.Errorf("argument #%d is not iterable: %s", i+1, arg.Type())
 		}
 		if err := func() error {
-			iter := iterable.Iterate()
+			iter := iterable.Iterate(NilThreadPlaceholder())
 			defer iter.Done()
 			return s.InsertAll(iter)
 		}(); err != nil {


### PR DESCRIPTION
## Summary
- pass a `*Thread` to `Iterate` interface methods
- adjust all implementations to accept the new parameter
- use `NilThreadPlaceholder()` at call sites

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68608853ef54832482b7c6b7f67a90cb