### PR TITLE
Add caching hit tests

### DIFF
--- a/starlark/testdata/cache.star
+++ b/starlark/testdata/cache.star
@@ -105,3 +105,17 @@ def f():
 assert.eq(f(), 1)
 mutable = 2
 assert.eq(f(), 2) # Modification of mutable invalidates g(), which is a dependency of f(), which invalidates f.
+
+---
+load("assert.star", "assert")
+
+s = sneaky()
+x = 1
+y = 2
+
+def copy_x_to_y():
+    y = x
+    return s()
+
+assert.eq(copy_x_to_y(), 1)
+assert.eq(copy_x_to_y(), 1) # cached because the function is idempotent

--- a/starlark/testdata/cache_dict.star
+++ b/starlark/testdata/cache_dict.star
@@ -189,4 +189,17 @@ assert.eq(mutable_len_with_union(), 1)
 mutable ["b"] = 2
 assert.eq(mutable_len_with_union(), 2)
 
-# TODO write positive cases where cache does hit
+---
+load("assert.star", "assert")
+
+s = sneaky()
+mutable = {"a": 1}
+
+def ensure_a():
+    mutable.setdefault("a", 1)
+    return s()
+
+assert.eq(ensure_a(), 1)
+assert.eq(ensure_a(), 1)  # cache holds because setdefault made no change
+mutable["b"] = 2
+assert.eq(ensure_a(), 2)  # modification busts the cache

--- a/starlark/testdata/cache_list.star
+++ b/starlark/testdata/cache_list.star
@@ -145,3 +145,18 @@ def list_is_true():
 assert.eq(list_is_true(), False)
 mutable.append(1)
 assert.eq(list_is_true(), True)
+
+---
+load("assert.star", "assert")
+
+s = sneaky()
+mutable = []
+
+def read_len_with_sneaky():
+    _ = len(mutable)
+    return s()
+
+assert.eq(read_len_with_sneaky(), 1)
+assert.eq(read_len_with_sneaky(), 1)  # cache holds while list is unchanged
+mutable.append(1)
+assert.eq(read_len_with_sneaky(), 2)  # modification busts the cache


### PR DESCRIPTION
## Summary
- expand cache tests with positive memoization cases
- cover read-only list/dict operations
- verify idempotent read/write caching with sneaky()

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6861898a7e088324862dfbd6c2375ea8